### PR TITLE
Added angle to neighbor detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Attempt at recreating the boids simulation by Craig Reynolds in Golang. 
 
 !! Attempting to add viewing angle to findNeighbors() which will make
-the simulation(hopefully) more realistic!!
+the simulation (hopefully) more realistic !!
 
 ## Rules
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Attempt at recreating the boids simulation by Craig Reynolds in Golang. 
 
+!! Attempting to add viewing angle to findNeighbors() which will make
+the simulation(hopefully) more realistic!!
+
 ## Rules
 
 The three rules that determine the boid's movements are 

--- a/pkg/boid/boid.go
+++ b/pkg/boid/boid.go
@@ -1,6 +1,10 @@
+// + Viewing angle seems to be working even though I don't know how to check it
+
 package boid
 
 import (
+	"math"
+
 	"github.com/strobosco/boids/pkg/constants"
 	"github.com/strobosco/boids/pkg/vector"
 )
@@ -27,10 +31,40 @@ const (
 	cohesionIndex    = constants.CohesionIndex    // * range at which cohesion is taken into account
 )
 
+func popNeighbor(slice []*Boid, i int) []*Boid {
+	new := []*Boid{}
+	for id, element := range slice {
+		if id != i {
+			new = append(new, element)
+		}
+	}
+	return new
+}
+
+func (s *Boid) inView(neighbors []*Boid) []*Boid {
+
+	boidAlfa := math.Atan((s.V.Y * math.Pi) / (s.V.X * 180))
+	boidAlfa = (180 * boidAlfa) / math.Pi
+	m1, m2 := boidAlfa-45, boidAlfa+45
+
+	for id, neighbor := range neighbors {
+		neighborM := (neighbor.O.Y - s.O.Y) / (neighbor.O.X - s.O.X)
+
+		if neighborM*neighbor.O.X < m1*neighbor.O.X && neighborM*neighbor.O.X > m2*neighbor.O.X {
+			neighbors = popNeighbor(neighbors, id)
+		}
+		if neighbor.O.Y/neighborM < neighbor.O.Y/m1 && neighbor.O.Y/neighborM > neighbor.O.Y/m2 {
+			neighbors = popNeighbor(neighbors, id)
+		}
+	}
+
+	return neighbors
+}
+
 /*
 * Function that checks if the boid is within the edges of the screen.
-* Could change and include mx = difference between screen width/height
-* and the image width/height.
+* (could change and include mx = difference between screen width/height
+* and the image width/height)
  */
 func (s *Boid) CheckEdges() {
 	if s.O.X < 0 {
@@ -59,6 +93,8 @@ func (s *Boid) FindNeighbors(boids []*Boid) []*Boid {
 			neighbors = append(neighbors, neighbor)
 		}
 	}
+
+	s.inView(neighbors)
 
 	return neighbors
 }

--- a/pkg/boid/boid.go
+++ b/pkg/boid/boid.go
@@ -94,7 +94,7 @@ func (s *Boid) FindNeighbors(boids []*Boid) []*Boid {
 		}
 	}
 
-	s.inView(neighbors)
+	neighbors = s.inView(neighbors)
 
 	return neighbors
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -9,5 +9,5 @@ const (
 	SeparationIndex  = 50.0  // * range at which separation is taken into account
 	AlignmentIndex   = 75.0  // * range at which alignment is taken into account
 	CohesionIndex    = 100.0 // * range at which cohesion is taken into account
-	NumBoids         = 250   // * number of boids
+	NumBoids         = 400   // * number of boids
 )


### PR DESCRIPTION
FindNeighbors() now only returns neighbors which are in a strict viewing angle. There is no way to verify if it has made a difference but it appears so visually (very minor changes in boid movement, both overall and singularly).